### PR TITLE
fix: set jwt correctly after register

### DIFF
--- a/logic/auth.ts
+++ b/logic/auth.ts
@@ -242,9 +242,7 @@ export async function seed(user: UserInfo): Promise<string[]> {
 export async function register(
   user: UserInfo,
   seed: string[],
-): Promise<{
-  jwt: string;
-}> {
+): Promise<string> {
   if (await isRegistered()) {
     throw new Error('User already exists');
   }
@@ -304,7 +302,7 @@ export async function register(
 
   await diskLogic.writeSignalFile('app-update');
   // Return token
-  return {jwt};
+  return jwt;
 }
 
 // Generate and return a new jwt token.


### PR DESCRIPTION
This is an old bug. Think William's fix was accidentally reverted in a large merge. Fixed in manager this time to keep correct types.
see https://github.com/runcitadel/dashboard/pull/4