### PR TITLE
Fix CI postinstall error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cors": "^2.8.5",
     "debug": "^4.3.3",
     "dotenv": "^16.0.0",
+    "husky": "^7.0.0",
     "iocane": "^5.1.1",
     "ioredis": "^4.28.5",
     "jsonwebtoken": "^8.5.1",
@@ -64,10 +65,8 @@
     "@types/passport-strategy": "^0.2.35",
     "@types/semver": "^7.3.9",
     "concurrently": "^7.0.0",
-    "husky": "^7.0.0",
     "nodemon": "^2.0.15",
     "npm-run-all": "^4.1.5",
-    "pinst": "^3.0.0",
     "typescript": "^4.6.2",
     "xo": "^0.48.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,7 +362,6 @@ __metadata:
     passport-http: ^0.3.0
     passport-jwt: ^4.0.0
     passport-strategy: ^1.0.0
-    pinst: ^3.0.0
     semver: ^7.3.5
     socks-proxy-agent: ^6.1.1
     thirty-two: ^1.0.2
@@ -5073,15 +5072,6 @@ __metadata:
   version: 3.0.0
   resolution: "pify@npm:3.0.0"
   checksum: 6cdcbc3567d5c412450c53261a3f10991665d660961e06605decf4544a61a97a54fefe70a68d5c37080ff9d6f4cf51444c90198d1ba9f9309a6c0d6e9f5c4fde
-  languageName: node
-  linkType: hard
-
-"pinst@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pinst@npm:3.0.0"
-  bin:
-    pinst: bin.js
-  checksum: 4ae48a6a60f79c37071233af51b4d91bfc85cfa3c12b66ccda60cdb642b4d14a4ab0cb3587afc55b1f6192cea1772a5e4822026a0d0d3528296edef00cc2d61f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
as a workaround move `husky` to production dependencies.

see https://github.com/typicode/husky/issues/939