### PR TITLE
Fix app generation

### DIFF
--- a/logic/auth.ts
+++ b/logic/auth.ts
@@ -285,6 +285,9 @@ export async function register(
     throw new Error('Unable to create seed');
   }
 
+  // Build app files with the seed existing
+  await runCommand('trigger app-update');
+
   // Generate JWt
   let jwt;
   try {


### PR DESCRIPTION
The app generation required the seed file, so for users starting their Citadel for the first time, the app store was empty.