### PR TITLE
Fix semver check

### DIFF
--- a/logic/system.ts
+++ b/logic/system.ts
@@ -148,6 +148,9 @@ export async function getAvailableUpdate(): Promise<versionFile | string> {
       isCompatibleWithCurrentVersion = semver.satisfies(
         currentVersion,
         requiresVersionRange,
+        {
+          includePrerelease: true,
+        },
       );
 
       // Calculate the minimum required version


### PR DESCRIPTION
Previously, the compatibility check always returned false with prerelease versions